### PR TITLE
feat: added ActiveAdmin 3.x compatibility

### DIFF
--- a/arctic_admin.gemspec
+++ b/arctic_admin.gemspec
@@ -9,13 +9,13 @@ Gem::Specification.new do |s|
   s.summary     = "Arctic Admin theme for ActiveAdmin"
   s.description = "A responsive theme for Active Admin"
   s.authors     = ["Clément Prod'homme"]
-  s.files       = Dir["{app,lib}/**/*"] + ["Readme.md", 'LICENCE.txt']
+  s.files       = Dir["{app,lib}/**/*"] + ["README.md", 'LICENCE.txt']
   s.homepage    = 'https://github.com/cle61/arctic_admin'
   s.license     = 'MIT'
   s.require_paths = ["lib"]
   s.add_development_dependency "bundler", "~> 1.5"
   s.add_development_dependency "rake"
-  s.add_dependency 'activeadmin', ['>= 1.1.0', '< 2.0']
+  s.add_dependency 'activeadmin', ['>= 1.1.0', '< 4.0']
   s.add_dependency 'jquery-rails'
   s.add_dependency 'font-awesome-sass', '~> 5.6.1'
 end

--- a/lib/arctic_admin/version.rb
+++ b/lib/arctic_admin/version.rb
@@ -1,3 +1,3 @@
 module ArcticAdmin
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
Modify gem to be compatible with ActiveAdmin 3. There were no actual incompatibilities, but it just needed to be marked as compatible